### PR TITLE
Sleep instead of spinning

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -17,5 +17,5 @@ int main() {
 
     signal(SIGINT, ctrlc);
 
-    for (;;) {}
+    Sleep(INFINITE);
 }


### PR DESCRIPTION
Main thread should sleep in order not to waste an entire CPU core.