### PR TITLE
Added workflow for automated releases and builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build release
+on: [push, workflow_dispatch]
+
+jobs:
+
+  build:
+    permissions: write-all
+    runs-on: windows-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: christophebedard/tag-version-commit@v1
+        id: new-tag
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version_tag_prefix: 'v'
+          version_regex: 'Version ([0-9]+\.[0-9]+\.[0-9]+)'
+        
+      - uses: ilammy/msvc-dev-cmd@v1
+      
+      - name: Build executable and dll
+        run: nmake
+
+      - name: Create Release
+        run: gh release create ${{ steps.new-tag.outputs.tag }} ./wm.exe ./wm_dll.dll -n "Version ${{ steps.new-tag.outputs.tag }}"


### PR DESCRIPTION
This PR adds a build workflow that operates in this manner:

1. Checks if the commit that was pushed is in the form `Version x.x.x` (e.g. `Version 1.0.2`)

![2024-01-27 12_03_21-Commits · albbus-stack_lightwm — Firefox Nightly](https://github.com/nir9/lightwm/assets/57916483/090e9aa5-f540-4ce6-8058-e665690bd9c4)

3. Creates a new tag for releasing based on the commit message
4. Builds the project with `nmake`

5. Creates the new release uploading the `.exe` and `.dll`

![2024-01-27 12_03_00-Release v1 0 2 · albbus-stack_lightwm — Firefox Nightly](https://github.com/nir9/lightwm/assets/57916483/8442184c-cb4b-4832-981e-6dfacff253ce)

You can then download the two files and run the wm with no errors. 

I'm just coming from Youtube, great video as always! I'm hoping that this repo will have more contributions 🤘