### PR TITLE
fix: made process DPI aware; fixes monitor scaling

### DIFF
--- a/wm.c
+++ b/wm.c
@@ -32,6 +32,8 @@ void ctrlc(int sig) {
 }
 
 int main() {
+    SetProcessDPIAware();
+
 	wmDll = LoadLibraryW(L"lightwm_dll");
 	
 	if (wmDll == NULL) {


### PR DESCRIPTION
- fixed fixed the issue where the tiling is set off center because of the monitor scaling

> NOTE: In the [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiaware) for this method it is mentioned that changing the dpi awareness over the Win32 API is not recommended. Instead the use of a manifest is advised but in think in this case the API is fine.

this PR refers to #10