### PR TITLE
Updated workflow to be only manually runnable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,11 @@
-name: Build Release
-on: [push, workflow_dispatch]
+name: Build & Release
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
 
 jobs:
-
   build:
     permissions: write-all
     runs-on: windows-latest
@@ -11,12 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-        #      - name: Setup Visual Studio Build Environment
-        #        run: |
-        #          & "C:/Program Files/Microsoft/Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat"
-        #
-        #      - name: Build Executable and DLL
-        #        run: nmake
+      # - name: Setup Visual Studio Build Environment & Build
+      #   run: |
+      #     & "C:/Program Files/Microsoft/Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvarsall.bat"
 
-      #- name: Create Release
-      #  run: gh release create ${{ github.sha }} ./wm.exe ./wm_dll.dll -n "Version ${{ github.sha }}"
+      - name: Setup Visual Studio Build Environment
+        uses: ilammy/msvc-dev-cmd@v1
+        
+      - name: Build Executable and DLL
+        run: nmake
+
+      - name: Create Release
+        run: gh release create ${{ github.event.inputs.version }} ./lightwm.exe ./lightwm_dll.dll -n "Version ${{ github.event.inputs.version }}"


### PR DESCRIPTION
This PR follows up on the previous one #7 where we discussed the behaviour for the workflow.
In particular this PR makes the workflow only runnable manually with a required `version` input:

![2024-02-05 10_33_48-Build   Release · Workflow runs · albbus-stack_lightwm — Firefox Nightly](https://github.com/nir9/lightwm/assets/57916483/f32e437f-0014-4ffc-9674-0973600b7e11)

It then builds the exe and dll using a public action to set up the dev environment (I left this because I wasn't able to setup the environment by myself running powershell commands). In light of the future zig build script this will be changed but _for now is fine_, since all that this action does is adding the proper build tools to PATH before being able to run `nmake`.