### PR TITLE
Added support for gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 EXE_SRCS = wm.c tiling.c error.c keyboard.c shared_mem.c
 DLL_SRCS = wm_dll.c error.c shared_mem.c
 
+#all: release_gcc
 all: debug release
 
 debug: prep wm.c
@@ -10,6 +11,10 @@ debug: prep wm.c
 release: prep wm.c
 	cl /Ox $(EXE_SRCS) /link kernel32.lib user32.lib /out:release/lightwm.exe /subsystem:windows /entry:wWinMain
 	cl /Ox $(DLL_SRCS) /LD /link kernel32.lib user32.lib /out:release/lightwm_dll.dll /subsystem:windows /entry:DllMain
+
+release_gcc: prep wm.c
+	gcc -shared -o release/lightwm_dll.dll $(DLL_SRCS) -lkernel32 -luser32 -Wl,-eDllMain
+	gcc -o release/lightwm.exe $(EXE_SRCS) -lkernel32 -luser32 -Wl,-ewWinMain -municode
 
 prep:
 	cmd /c IF NOT EXIST debug mkdir debug


### PR DESCRIPTION
Whenever I compiled the program normally I got a "GetProcAdress for shell proc" error but when I compiled it with gcc it worked so I guess it would be a good idea to add support for multiple compilers